### PR TITLE
Add support of high resolution naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# Gulp CMS_REF Replacement Plugin
 Gulp plugin to replace all media occurrences in CSS files with
 [FirstSpirit](http://www.e-spirit.com/de/product/advantage/advantages.html)
 CMS_REF tags:
@@ -14,3 +15,13 @@ cmsref({
     "image-filename.jpg": "my_image_jpg"
 })
 ```
+## High resolution image naming convention
+The common naming convention for high resolution images is to increase the pixelratio and place it inside of the filename.
+
+`my-image.png` is also available for high resolution displays as `my-image@2x.png`.
+
+This plugin will transform high resolution image naming convention like this:
+
+`url("../path/to/my-image@2x.png") → url("$CMS_REF(media:"my_image_2x")$")`
+
+Please note, that FirstSpirit will transform `my-image@2x.png` to `my_image_1`, because `my-image.png` will use the reference name already. This might be confusing. A recommendation is to set the reference name of retina images like above with `my_image_2x` to make clear which pixelratio will be used.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var es = require('event-stream');
 var stream = require('stream');
 var istextorbinary = require('istextorbinary');
-var re = /(=|url\()(["'`]?){1}(?!\/\/)([a-z0-9_\/.-@]+\.[a-z0-9]+)(?:[#?].+?)?\2/gim;
+var re = /(=|url\()(["'`]?){1}(?!\/\/)([a-z0-9_\/.@-]+\.[a-z0-9]+)(?:[#?].+?)?\2/gim;
 
 module.exports = function(map, options) {
     var doCMSReplace = function(file, callback) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var es = require('event-stream');
 var stream = require('stream');
 var istextorbinary = require('istextorbinary');
-var re = /(=|url\()(["'`]?){1}(?!\/\/)([a-z0-9_\/.-]+\.[a-z0-9]+)(?:[#?].+?)?\2/gim;
+var re = /(=|url\()(["'`]?){1}(?!\/\/)([a-z0-9_\/.-@]+\.[a-z0-9]+)(?:[#?].+?)?\2/gim;
 
 module.exports = function(map, options) {
     var doCMSReplace = function(file, callback) {
@@ -28,11 +28,11 @@ module.exports = function(map, options) {
                         replacement = replacement.join('.').toLowerCase().replace(/[^a-z0-9_]+/g, '_');
                     }
 
-                    // Important: $ is a special char inside the 2. argument of 
+                    // Important: $ is a special char inside the 2. argument of
                     // String.replace.
-                    // To insert a normal $ sign "$$" needs to be used to escape 
+                    // To insert a normal $ sign "$$" needs to be used to escape
                     // the second $.
-                    // Additionally, because the result of this replacement will 
+                    // Additionally, because the result of this replacement will
                     // be used again for another replacement it is neccessary to
                     // escape the $ sign twice.
                     replacement = match[0].replace(match[3], '$$$$CMS_REF(media:"' + replacement + '")$$$$');


### PR DESCRIPTION
The common naming convention for high resolution images is to increase the pixelratio and place it inside of the filename.

`my-image.png` is also available for high resolution displays as `my-image@2x.png`.

This plugin will transform high resolution image naming convention like this:

`url("../path/to/my-image@2x.png") → url("$CMS_REF(media:"my_image_2x")$")`

Please note, that FirstSpirit will transform `my-image@2x.png` to `my_image_1`, because `my-image.png` will use the reference name already. This might be confusing. A recommendation is to set the reference name of retina images like above with `my_image_2x` to make clear which pixel ratio will be used.